### PR TITLE
Support for all Ragalahari image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Ragalahari downloader will help you to download hundreds of High Quality (HD+ &a
 ## Project setup
 
 ```
+pip3 install -r requirements.txt
 python3 downloader.py
 ```
 

--- a/downloader.py
+++ b/downloader.py
@@ -5,9 +5,9 @@ import os.path
 import urllib.request
 import sys
 import traceback
-
 import requests
 import subprocess as sp
+import shutil
 
 idLists = []
 
@@ -84,8 +84,15 @@ def welcomeBanner():
 def downloadImg(filePath, folderName):
     print(bcolors.OKGREEN +
           "-----------------------------------------------------------------------")
+    os.chdir(folderName)
     for x in idLists:
-        urllib.request.urlretrieve(filePath + x, folderName + "/" + x)
+        r = requests.get(filePath + x, stream = True)
+        r.raw.decode_content = True
+        
+        """ Used shutil to download the image """
+        with open(x,'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+        #urllib.request.urlretrieve(filePath + x, folderName + "/" + x)
         print(bcolors.OKGREEN + x + " - Saved successfully!")
     print(bcolors.OKGREEN +
           "-----------------------------------------------------------------------")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+


### PR DESCRIPTION
Modified the function 'downloadImg(filePath, folderName)' to download using shutil which now does not cause Error 403 (HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden) 
The new script is faster and also works for older urls like:
	https://img.ragalahari.com/
	https://starzone.ragalahari.com/

Added a requirements.txt file to install requests using pip